### PR TITLE
Fixed service crash when Consul is stopped

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.0 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.0 // indirect
 	github.com/hashicorp/serf v0.8.2 // indirect
-	github.com/mitchellh/consulstructure v0.0.0-20160324233621-b407c521973b
+	github.com/mitchellh/consulstructure v0.0.0-20190329231841-56fdc4d2da54
 	github.com/mitchellh/copystructure v1.0.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.1.2 // indirect

--- a/internal/pkg/consul/client.go
+++ b/internal/pkg/consul/client.go
@@ -188,9 +188,12 @@ func (client *consulClient) GetConfiguration(configStruct interface{}) (interfac
 	decoder.ErrCh = errorChannel
 	decoder.UpdateCh = updateChannel
 
-	defer decoder.Close()
-	defer close(updateChannel)
-	defer close(errorChannel)
+	defer func() {
+		decoder.Close()
+		close(updateChannel)
+		close(errorChannel)
+	}()
+
 	go decoder.Run()
 
 	select {
@@ -220,8 +223,6 @@ func (client *consulClient) WatchForChanges(updateChannel chan<- interface{}, er
 	decoder.Prefix = client.configBasePath + watchKey
 	decoder.ErrCh = errorChannel
 	decoder.UpdateCh = updateChannel
-
-	defer decoder.Close()
 
 	go decoder.Run()
 }


### PR DESCRIPTION
This PR addresses #3 
My fix to mitchellh/consulstructure was accepted and merged.

These changes use latest  mitchellh/consulstructure, properly close channels after decoder.close completes and in watching for changes, never closes the decoder, which would now be an issue.
