### PR TITLE
refactor (go.mod): Switch to use github.com/hashicorp/consul/api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,19 +1,11 @@
 module github.com/edgexfoundry/go-mod-registry
 
 require (
-	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
-	github.com/hashicorp/consul v1.3.1
-	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
-	github.com/hashicorp/go-rootcerts v1.0.1 // indirect
-	github.com/hashicorp/serf v0.8.3 // indirect
+	github.com/hashicorp/consul/api v1.1.0
 	github.com/mitchellh/consulstructure v0.0.0-20190329231841-56fdc4d2da54
 	github.com/mitchellh/copystructure v1.0.0 // indirect
-	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
-	github.com/mitchellh/mapstructure v1.1.2 // indirect
-	github.com/pascaldekloe/goe v0.1.0 // indirect
 	github.com/pelletier/go-toml v1.2.0
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
-	gopkg.in/yaml.v2 v2.2.2 // indirect
 )


### PR DESCRIPTION
API package is all that is required from `github.com/hashicorp/consul`. This reduces indirect dependencies

closes #24 
