### PR TITLE
Updated GetServiceEndpoint logic to return error on no match found

### DIFF
--- a/internal/pkg/consul/client.go
+++ b/internal/pkg/consul/client.go
@@ -296,6 +296,8 @@ func (client *consulClient) GetServiceEndpoint(serviceID string) (types.ServiceE
 		endpoint.Port = service.Port
 		endpoint.ServiceId = serviceID
 		endpoint.Host = service.Address
+	} else {
+		return types.ServiceEndpoint{}, fmt.Errorf("no matching service endpoint found")
 	}
 
 	return endpoint, nil

--- a/internal/pkg/consul/client.go
+++ b/internal/pkg/consul/client.go
@@ -284,7 +284,8 @@ func (client *consulClient) PutConfigurationValue(name string, value []byte) err
 	return nil
 }
 
-// Gets the service endpoint information for the target ID from Consul
+// GetServiceEndpoint retrieves the port, service ID and host of a known endpoint from Consul.
+// If this operation is successful and a known endpoint is found, it is returned. Otherwise, an error is returned.
 func (client *consulClient) GetServiceEndpoint(serviceID string) (types.ServiceEndpoint, error) {
 	services, err := client.consulClient.Agent().Services()
 	if err != nil {

--- a/internal/pkg/consul/client_test.go
+++ b/internal/pkg/consul/client_test.go
@@ -248,7 +248,7 @@ func TestGetServiceEndpoint(t *testing.T) {
 
 	// Test for endpoint not found
 	actualEndpoint, err := client.GetServiceEndpoint(client.serviceKey)
-	if !assert.NoError(t, err) {
+	if !assert.Error(t, err) {
 		t.Fatal()
 	}
 	if !assert.Equal(t, expectedNotFoundEndpoint, actualEndpoint, "Test for endpoint not found result not as expected") {


### PR DESCRIPTION
While working https://github.com/edgexfoundry/edgex-go/issues/2237 I noticed this code does not return any sort of feedback when no match is found; it just silently returns an empty endpoint.

This seemed like odd behavior and I am submitting a PR. If this expected behavior, please close.

Signed-off-by: Brandon Forster <brandonforster@gmail.com>