### PR TITLE
Add minimum supported Go version 1.12 to go.mod.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,5 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
 )
+
+go 1.12


### PR DESCRIPTION
Fix #36 

Locally, I upgraded to Go `1.12`, and tested it out via `Makefile`.