### PR TITLE
Enabled -race for go test in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 .PHONY: test
 
-GO=CGO_ENABLED=0 GO111MODULE=on go
+GO=CGO_ENABLED=1 GO111MODULE=on go
 
 test:
-	$(GO) test ./... -coverprofile=coverage.out ./...
+	$(GO) test -race ./... -coverprofile=coverage.out ./...
 	$(GO) vet ./...
 	gofmt -l .
 	[ "`gofmt -l .`" = "" ]


### PR DESCRIPTION
After reviewing the initial issue, it appears that all tests do pass
with the `go test -race` flag. However this flag is not enabled during
build verification b/c it is not included in the Makefile. I made the
change to include it.

In order to test locally with `-race` enabled, simply type `make test`.

Fix #35

Signed-off-by: Trevor Conn <trevor_conn@dell.com>
