### PR TITLE
fix(registry):register health check w/ service key

### DIFF
--- a/internal/pkg/consul/client.go
+++ b/internal/pkg/consul/client.go
@@ -104,6 +104,7 @@ func (client *consulClient) Register() error {
 
 	// Register for Health Check
 	err = client.consulClient.Agent().CheckRegister(&consulapi.AgentCheckRegistration{
+		ID:        client.serviceKey,
 		Name:      "Health Check: " + client.serviceKey,
 		Notes:     "Check the health of the API",
 		ServiceID: client.serviceKey,


### PR DESCRIPTION
Clean up register/deregister inconsistency discussed in #57

Signed-off-by: Alex Ullrich <alexullrich@technotects.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Does not seem to show up in practice but the service check does not get registered/deregistered using the same key in code.
Issue Number: #57 


## What is the new behavior?
Register using the service key (same value used to deregister already) 

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information