### PR TITLE
feat(registry): Additional Check Registration

### DIFF
--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -52,7 +52,11 @@ func (config Config) GetRegistryUrl() string {
 }
 
 func (config Config) GetHealthCheckUrl() string {
-	return fmt.Sprintf("%s://%s:%v%s", config.GetServiceProtocol(), config.ServiceHost, config.ServicePort, config.CheckRoute)
+	return config.GetExpandedRoute(config.CheckRoute)
+}
+
+func (config Config) GetExpandedRoute(route string) string {
+	return fmt.Sprintf("%s://%s:%v%s", config.GetServiceProtocol(), config.ServiceHost, config.ServicePort, route)
 }
 
 func (config Config) GetRegistryProtocol() string {

--- a/registry/interface.go
+++ b/registry/interface.go
@@ -27,6 +27,9 @@ type Client interface {
 	// Un-registers the current service with Registry for discover and health check
 	Unregister() error
 
+	// Registers a
+	RegisterCheck(id string, name string, notes string, url string, interval string) error
+
 	// Simply checks if Registry is up and running at the configured URL
 	IsAlive() bool
 


### PR DESCRIPTION
Allow using registry client to register/deregister custom checks with
consul.

Signed-off-by: Alex Ullrich <alexullrich@technotects.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-registry/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Does not support adding additional checks

## Issue Number:
#64 

## What is the new behavior?
RegistryClient interface and consul implementation support registering / deregistering custom health checks.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

Custom registry clients would need to implement the new methods.

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [ ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information